### PR TITLE
✨Create tags that can be removed easily #36

### DIFF
--- a/frontend/mobile_app_react_native/__tests__/actions/utils.test.ts
+++ b/frontend/mobile_app_react_native/__tests__/actions/utils.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import stringToHash from "../../actions/utils/stringToHash"
+
+
+describe('Testing some utils', () => {
+    describe ('String to tag', () => {
+        it('Should be a number', () =>
+            expect(
+                typeof(stringToHash("hola"))
+            ).equals(
+                "number"
+            )
+        )
+        it('Should be different', () =>
+            expect(
+               stringToHash("hola") == stringToHash("hila") 
+            ).equals(
+                false
+            )
+        )
+    })
+
+})

--- a/frontend/mobile_app_react_native/actions/utils/stringToHash.ts
+++ b/frontend/mobile_app_react_native/actions/utils/stringToHash.ts
@@ -1,0 +1,11 @@
+const stringToHash = (word : String): number => {
+    const number = word.split('')
+                       .map( e => e.charCodeAt(0))
+                       .reduce(
+                        (previous, current) => previous *100 + current,
+                        0
+                       );
+    return number;
+                    
+}
+export default stringToHash

--- a/frontend/mobile_app_react_native/components/TagInput.tsx/CustomTag.tsx
+++ b/frontend/mobile_app_react_native/components/TagInput.tsx/CustomTag.tsx
@@ -1,0 +1,60 @@
+import { Box, Button, CloseIcon, Flex, HStack, Spacer, Text } from "native-base";
+import React from "react";
+import {StyleSheet} from "react-native";
+import { interfaceTagStructure } from "../../views/search/search";
+
+interface tagInterface {
+    tag : String,
+    tagsList : interfaceTagStructure,
+    tagsListSetter : any
+}
+
+const CustomTag = ({tag, tagsList, tagsListSetter}:tagInterface) =>{
+    return (
+        <Flex style={style.container}>
+            <HStack>
+                <Text>{tag}</Text>
+                <Spacer />
+                <Button 
+                    style={style.button}
+                    onPressOut ={
+                        () =>{
+                            tagsListSetter(
+                                {
+                                    list:tagsList.list.filter(e => e != tag),
+                                    state: ! tagsList.state
+                                }
+                            )
+                        }
+                    }
+                > 
+                    <CloseIcon />
+                </Button>
+            </HStack>
+        </Flex>
+    )
+}
+
+export default CustomTag
+
+const style = StyleSheet.create({
+    button :{
+        width : 40,
+        height: 23,
+        backgroundColor: "transparent",
+    },
+    container :{
+        margin: 10,
+        padding:5,
+        paddingRight:0,
+        width: "auto",
+        height: 30,
+
+        borderWidth: 1,
+        borderRadius:10,
+
+        justifyContent: "center",
+        alignItems: "center",
+        
+    }
+})

--- a/frontend/mobile_app_react_native/components/TagInput.tsx/TagInput.tsx
+++ b/frontend/mobile_app_react_native/components/TagInput.tsx/TagInput.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
-import { HStack, Input, Text, VStack} from "native-base";
+import { HStack, Input, Tag, Text, VStack} from "native-base";
 import { StyleSheet } from "react-native";
 import AddButton from "./AddButton";
 import { interfaceTagStructure } from "../../views/search/search";
+import CustomTag from "./CustomTag";
+import stringToHash from "../../actions/utils/stringToHash";
 
 interface tagInputInterface {
     tagsList: interfaceTagStructure;
@@ -20,8 +22,12 @@ const TagInput = ({tagsList, tagsListSetter}:tagInputInterface) => {
             />
             <HStack>
                 {
+                    //TODO añadir aquí como botón el tag, la acción coge la tagList y "actualiza el tag sin la lista".
+
                     tagsList.list.map(
-                        tag => <Text key={Math.random()}> {tag} </Text>
+                        tag => <CustomTag key={stringToHash(tag)} 
+                        tag={tag} tagsList={tagsList} 
+                        tagsListSetter={tagsListSetter} />
                     )
                 }
             </HStack>
@@ -35,5 +41,4 @@ const style = StyleSheet.create({
         alignItems: "center",
         margin: 10
     }
-
 })


### PR DESCRIPTION
This commit 
- Fixed #36 since it enable a way of removing tags  from the searching view 
- This is also the ending of: 
- closes #28 since it finished an preview of the content
- closes #27 since no more backend it necessary for searching cards